### PR TITLE
feat: add GIR fixup scripts

### DIFF
--- a/gir-fixes/gnome44.sh
+++ b/gir-fixes/gnome44.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+input_dir=${1?Missing input directory}
+output_dir=${2?Missing output directory}
+
+mkdir -p "$output_dir"

--- a/gir-fixes/gnome45.sh
+++ b/gir-fixes/gnome45.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+input_dir=${1?Missing input directory}
+output_dir=${2?Missing output directory}
+
+mkdir -p "$output_dir"
+
+# GObject-2.0
+xmlstarlet ed \
+    `# https://github.com/ianprime0509/zig-gobject/issues/37` \
+    --var TypeCValue '//_:union[@name="TypeCValue"]' \
+    \
+    --subnode '$TypeCValue' -t elem -n field \
+    --var v_int '$prev' \
+    --subnode '$v_int' -t attr -n name -v v_int \
+    --subnode '$v_int' -t elem -n type \
+    --var v_int_type '$prev' \
+    --subnode '$v_int_type' -t attr -n name -v gint \
+    --subnode '$v_int_type' -t attr -n c:type -v gint \
+    \
+    --subnode '$TypeCValue' -t elem -n field \
+    --var v_long '$prev' \
+    --subnode '$v_long' -t attr -n name -v v_long \
+    --subnode '$v_long' -t elem -n type \
+    --var v_long_type '$prev' \
+    --subnode '$v_long_type' -t attr -n name -v glong \
+    --subnode '$v_long_type' -t attr -n c:type -v glong \
+    \
+    --subnode '$TypeCValue' -t elem -n field \
+    --var v_int64 '$prev' \
+    --subnode '$v_int64' -t attr -n name -v v_int64 \
+    --subnode '$v_int64' -t elem -n type \
+    --var v_int64_type '$prev' \
+    --subnode '$v_int64_type' -t attr -n name -v gint64 \
+    --subnode '$v_int64_type' -t attr -n c:type -v gint64 \
+    \
+    --subnode '$TypeCValue' -t elem -n field \
+    --var v_double '$prev' \
+    --subnode '$v_double' -t attr -n name -v v_double \
+    --subnode '$v_double' -t elem -n type \
+    --var v_double_type '$prev' \
+    --subnode '$v_double_type' -t attr -n name -v gdouble \
+    --subnode '$v_double_type' -t attr -n c:type -v gdouble \
+    \
+    --subnode '$TypeCValue' -t elem -n field \
+    --var v_pointer '$prev' \
+    --subnode '$v_pointer' -t attr -n name -v v_pointer \
+    --subnode '$v_pointer' -t elem -n type \
+    --var v_pointer_type '$prev' \
+    --subnode '$v_pointer_type' -t attr -n name -v gpointer \
+    --subnode '$v_pointer_type' -t attr -n c:type -v gpointer \
+    "$1"/GObject-2.0.gir >"$2"/GObject-2.0.gir

--- a/test/build.zig
+++ b/test/build.zig
@@ -243,8 +243,8 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Run binding tests");
 
     const GirProfile = enum { gnome44, gnome45 };
-    const gir_profile = b.option(GirProfile, "gir-profile", "Predefined GIR profile for tests") orelse .gnome45;
-    const test_modules: []const []const u8 = b.option([]const []const u8, "modules", "Modules to test") orelse switch (gir_profile) {
+    const gir_profile = b.option(GirProfile, "gir-profile", "Predefined GIR profile for tests");
+    const test_modules: []const []const u8 = b.option([]const []const u8, "modules", "Modules to test") orelse if (gir_profile) |profile| switch (profile) {
         .gnome44 => &.{
             "Adw-1",
             "AppStreamGlib-1.0",
@@ -452,7 +452,7 @@ pub fn build(b: *std.Build) !void {
             "Xmlb-2.0",
             "xrandr-1.3",
         },
-    };
+    } else @panic("No modules or GIR profile provided to test");
 
     for (test_modules) |test_module| {
         const module = try std.ascii.allocLowerString(b.allocator, test_module);


### PR DESCRIPTION
Works around #37 and potential future issues of the same kind

This commit adds the ability to run a "fixup script" on the input system GIR files, which is expected to output any necessary overrides (created via patching, etc.) to a target directory. The codegen process will use these fixed up files in preference to its own.

---

Issues to be resolved prior to merge:

- [ ] `xmlstarlet` is not available in the GNOME SDK Flatpak containers, making this rather tedious to execute in the intended way described in the README
- [ ] Update documentation for this feature
- [ ] Make sure this feature integrates well with the cache system