### PR TITLE
fix: resolve type mismatch for bool and string properties

### DIFF
--- a/extensions/gobject2.zig
+++ b/extensions/gobject2.zig
@@ -605,7 +605,7 @@ pub fn defineProperty(
                     name,
                     options.nick orelse null,
                     options.blurb orelse null,
-                    options.default,
+                    @intFromBool(options.default),
                     flags,
                 );
             } else if (Data == c_int) {
@@ -1154,7 +1154,12 @@ pub const Value = struct {
         } else if (T == f64) {
             value.setDouble(contents);
         } else if (comptime isCString(T)) {
-            value.setString(contents);
+            // orelse null as temporary workaround for https://github.com/ziglang/zig/issues/12523
+            switch (@typeInfo(T)) {
+                .Pointer => value.setString(contents),
+                .Optional => value.setString(contents orelse null),
+                else => unreachable,
+            }
         } else if (std.meta.hasFn(T, "getGObjectType")) {
             switch (@typeInfo(T)) {
                 .Enum => value.setEnum(@intFromEnum(contents)),


### PR DESCRIPTION
This PR fixes two issues:
- `bool`s in `gobject.ext.defineProperty()` require converting to `c_int` in order to be compatible with the C API
- optional strings did not work with `gobject.ext.Value.set()` due to a [compiler bug](https://github.com/ziglang/zig/issues/12523)

With these fixes, it is now also possible to create properties of type `bool` or `?[:0]const u8`.