### PR TITLE
Restore compatibility with Zig master

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ exe.root_module.addImport("gtk", gobject.module("gtk-4.0"));
 exe.root_module.addImport("adw", gobject.module("adw-1"));
 ```
 
-The generated bindings are primarily tested with Zig 0.13.0, but should also
-work with 0.12.0 and master. The binding generator supports only Zig 0.13.0;
-other versions of Zig may or may not work.
+The generated bindings are tested on Zig 0.13.0 and master, though support for
+the latest master may temporarily regress when breaking changes are made
+upstream. The binding generator itself targets only the latest Zig master.
 
 ## Companion projects
 

--- a/binding-overrides/cairo1.zig
+++ b/binding-overrides/cairo1.zig
@@ -1,3 +1,5 @@
+const compat = @import("compat");
+
 extern fn cairo_version() c_int;
 pub const version = cairo_version;
 
@@ -1179,7 +1181,7 @@ pub const TextCluster = extern struct {
 
 pub const TextClusterFlags = packed struct(c_int) {
     backward: bool,
-    _: @Type(.{ .int = .{ .signedness = .unsigned, .bits = @bitSizeOf(c_int) - 1 } }) = 0,
+    _: compat.Reify(.{ .int = .{ .signedness = .unsigned, .bits = @bitSizeOf(c_int) - 1 } }) = 0,
 };
 
 pub const TextExtents = extern struct {

--- a/binding-overrides/cairo1.zig
+++ b/binding-overrides/cairo1.zig
@@ -1179,7 +1179,7 @@ pub const TextCluster = extern struct {
 
 pub const TextClusterFlags = packed struct(c_int) {
     backward: bool,
-    _: @Type(.{ .Int = .{ .signedness = .unsigned, .bits = @bitSizeOf(c_int) - 1 } }) = 0,
+    _: @Type(.{ .int = .{ .signedness = .unsigned, .bits = @bitSizeOf(c_int) - 1 } }) = 0,
 };
 
 pub const TextExtents = extern struct {

--- a/doc/binding-strategy.md
+++ b/doc/binding-strategy.md
@@ -107,7 +107,7 @@ pub fn implement(
     /// The type struct instance on which to implement the method.
     class: anytype,
     /// The implementation of the method.
-    impl: *const fn(*@typeInfo(@TypeOf(class)).Pointer.child.Instance, ...method parameters...) ...method return type...,
+    impl: *const fn(*@typeInfo(@TypeOf(class)).pointer.child.Instance, ...method parameters...) ...method return type...,
 )
 ```
 

--- a/doc/binding-strategy.md
+++ b/doc/binding-strategy.md
@@ -24,6 +24,31 @@ such as the use of the correct pointer type `?[*:0]const u8` for the application
 ID, rather than the limited `[*c]const u8` which `zig translate-c` would
 produce.
 
+## Naming
+
+Zig and GObject-based libraries have different naming conventions in some
+aspects, and Zig also enforces more stringent naming practices in several ways:
+for example, fields and decls may not have the same name, names may not shadow
+others in their enclosing scope. The generated bindings rename the original
+library symbols as follows:
+
+- Namespace names: lowercased (e.g. `Gtk` becomes `gtk`).
+- Type names: remain the same, as GObject and Zig both use `PascalCase`.
+  - Exception: type names which would conflict with one of the built-in
+    metadata fields are "mangled" by adding a trailing `_`. For example, a type
+    in a library originally named `Class` will be translated as `Class_`.
+- Function names: translated from `snake_case` into `camelCase` (e.g.
+  `signal_connect_data` becomes `signalConnectData`).
+- Constant names: remain the same. Although Zig prefers lowercase constant
+  names, in contrast to GObject's `SCREAMING_SNAKE_CASE`, uniformly lowercasing
+  constant names would lead to some conflicts (e.g. GDK's `KEY_A` and `KEY_a`
+  would become ambiguous).
+- Enum and bit field (flags) members: remain the same (`snake_case`).
+- Field names: remain the same, but prefixed with `f_` to avoid potentially
+  conflicting with other declarations on the types.
+- Parameter names: remain the same, but prefixed with `p_` to avoid potentially
+  shadowing other names in the enclosing scope.
+
 ## Usage conventions
 
 While it is possible for functions in Zig to be called using method call syntax

--- a/extensions/gobject2.zig
+++ b/extensions/gobject2.zig
@@ -145,9 +145,9 @@ pub fn implement(comptime Iface: type, comptime options: ImplementOptions(Iface)
     return .{
         .Iface = Iface,
         .info = .{
-            .interface_init = @ptrCast(options.init),
-            .interface_finalize = @ptrCast(options.finalize),
-            .interface_data = null,
+            .f_interface_init = @ptrCast(options.init),
+            .f_interface_finalize = @ptrCast(options.finalize),
+            .f_interface_data = null,
         },
     };
 }
@@ -222,17 +222,17 @@ pub fn defineClass(
                         }
                     }
                 }.classInit;
-                const info = gobject.TypeInfo{
-                    .class_size = @sizeOf(Instance.Class),
-                    .base_init = @ptrCast(options.baseInit),
-                    .base_finalize = @ptrCast(options.baseFinalize),
-                    .class_init = @ptrCast(&classInitFunc),
-                    .class_finalize = @ptrCast(options.classFinalize),
-                    .class_data = null,
-                    .instance_size = @sizeOf(Instance),
-                    .n_preallocs = 0,
-                    .instance_init = @ptrCast(options.instanceInit),
-                    .value_table = null,
+                const info: gobject.TypeInfo = .{
+                    .f_class_size = @sizeOf(Instance.Class),
+                    .f_base_init = @ptrCast(options.baseInit),
+                    .f_base_finalize = @ptrCast(options.baseFinalize),
+                    .f_class_init = @ptrCast(&classInitFunc),
+                    .f_class_finalize = @ptrCast(options.classFinalize),
+                    .f_class_data = null,
+                    .f_instance_size = @sizeOf(Instance),
+                    .f_n_preallocs = 0,
+                    .f_instance_init = @ptrCast(options.instanceInit),
+                    .f_value_table = null,
                 };
 
                 const type_id = gobject.typeRegisterStatic(

--- a/extensions/gtk4.zig
+++ b/extensions/gtk4.zig
@@ -57,17 +57,17 @@ pub const impl_helpers = struct {
     }
 
     fn ensureWidgetType(comptime Container: type, comptime field_name: []const u8) void {
-        inline for (@typeInfo(Container).Struct.fields) |field| {
+        inline for (@typeInfo(Container).@"struct".fields) |field| {
             if (comptime std.mem.eql(u8, field.name, field_name)) {
                 const WidgetType = switch (@typeInfo(field.type)) {
-                    .Pointer => |pointer| widget_type: {
+                    .pointer => |pointer| widget_type: {
                         if (pointer.size != .One) {
                             @compileError("bound child type must be a single pointer");
                         }
                         break :widget_type pointer.child;
                     },
-                    .Optional => |optional| switch (@typeInfo(optional.child)) {
-                        .Pointer => |pointer| widget_type: {
+                    .optional => |optional| switch (@typeInfo(optional.child)) {
+                        .pointer => |pointer| widget_type: {
                             if (pointer.size != .One) {
                                 @compileError("bound child type must be a single pointer");
                             }

--- a/extensions/gtk4.zig
+++ b/extensions/gtk4.zig
@@ -2,6 +2,7 @@ const glib = @import("glib2");
 const gobject = @import("gobject2");
 const gtk = @import("gtk4");
 const std = @import("std");
+const compat = @import("compat");
 
 pub const BindTemplateChildOptions = struct {
     field: ?[]const u8 = null,
@@ -57,16 +58,16 @@ pub const impl_helpers = struct {
     }
 
     fn ensureWidgetType(comptime Container: type, comptime field_name: []const u8) void {
-        inline for (@typeInfo(Container).@"struct".fields) |field| {
+        inline for (compat.typeInfo(Container).@"struct".fields) |field| {
             if (comptime std.mem.eql(u8, field.name, field_name)) {
-                const WidgetType = switch (@typeInfo(field.type)) {
+                const WidgetType = switch (compat.typeInfo(field.type)) {
                     .pointer => |pointer| widget_type: {
                         if (pointer.size != .One) {
                             @compileError("bound child type must be a single pointer");
                         }
                         break :widget_type pointer.child;
                     },
-                    .optional => |optional| switch (@typeInfo(optional.child)) {
+                    .optional => |optional| switch (compat.typeInfo(optional.child)) {
                         .pointer => |pointer| widget_type: {
                             if (pointer.size != .One) {
                                 @compileError("bound child type must be a single pointer");

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,108 @@
+//! Compatibility wrappers for the latest tagged release of Zig.
+
+const std = @import("std");
+const expect = std.testing.expect;
+
+/// https://github.com/ziglang/zig/pull/21225
+pub const TypeInfo = if (type_has_new_fields) std.builtin.Type else TypeCompat;
+
+const type_has_new_fields = @hasField(std.builtin.Type, "type");
+
+pub fn typeInfo(comptime T: type) TypeInfo {
+    if (type_has_new_fields) return @typeInfo(T);
+    return switch (@typeInfo(T)) {
+        inline else => |info, tag| @unionInit(TypeInfo, type_new_fields.get(@tagName(tag)).?, info),
+    };
+}
+
+test typeInfo {
+    const MyStruct = struct {
+        a: u32,
+        b: []const u8,
+    };
+    const type_info = typeInfo(MyStruct);
+    try expect(type_info == .@"struct");
+    try expect(type_info.@"struct".fields.len == 2);
+    try expect(type_info.@"struct".fields[0].type == u32);
+    try expect(type_info.@"struct".fields[1].type == []const u8);
+}
+
+pub fn Reify(comptime type_info: TypeInfo) type {
+    if (type_has_new_fields) return @Type(type_info);
+    return @Type(switch (type_info) {
+        inline else => |info, tag| @unionInit(std.builtin.Type, type_old_fields.get(@tagName(tag)).?, info),
+    });
+}
+
+test Reify {
+    const MyU32 = Reify(.{ .int = .{
+        .bits = 32,
+        .signedness = .unsigned,
+    } });
+    const value: MyU32 = 123;
+    try expect(@TypeOf(value) == u32);
+}
+
+const type_field_names: []const struct { [:0]const u8, [:0]const u8 } = &.{
+    .{ "Type", "type" },
+    .{ "Void", "void" },
+    .{ "Bool", "bool" },
+    .{ "NoReturn", "noreturn" },
+    .{ "Int", "int" },
+    .{ "Float", "float" },
+    .{ "Pointer", "pointer" },
+    .{ "Array", "array" },
+    .{ "Struct", "struct" },
+    .{ "ComptimeFloat", "comptime_float" },
+    .{ "ComptimeInt", "comptime_int" },
+    .{ "Undefined", "undefined" },
+    .{ "Null", "null" },
+    .{ "Optional", "optional" },
+    .{ "ErrorUnion", "error_union" },
+    .{ "ErrorSet", "error_set" },
+    .{ "Enum", "enum" },
+    .{ "Union", "union" },
+    .{ "Fn", "fn" },
+    .{ "Opaque", "opaque" },
+    .{ "Frame", "frame" },
+    .{ "AnyFrame", "anyframe" },
+    .{ "Vector", "vector" },
+    .{ "EnumLiteral", "enum_literal" },
+};
+
+const type_new_fields = std.StaticStringMap([:0]const u8).initComptime(type_field_names);
+const type_old_fields = type_old_fields: {
+    var mappings: [type_field_names.len]struct { [:0]const u8, [:0]const u8 } = undefined;
+    for (type_field_names, &mappings) |old_to_new, *new_to_old| {
+        new_to_old.* = .{ old_to_new[1], old_to_new[0] };
+    }
+    break :type_old_fields std.StaticStringMap([:0]const u8).initComptime(mappings);
+};
+
+const TypeCompat = TypeCompat: {
+    var builtin_type = @typeInfo(std.builtin.Type).Union;
+    var builtin_type_tag = @typeInfo(builtin_type.tag_type.?).Enum;
+
+    var compat_type_tag_fields = builtin_type_tag.fields[0..builtin_type_tag.fields.len].*;
+    for (&compat_type_tag_fields) |*field| {
+        field.name = type_new_fields.get(field.name).?;
+    }
+    const TypeCompatTag = @Type(.{ .Enum = .{
+        .tag_type = builtin_type_tag.tag_type,
+        .fields = &compat_type_tag_fields,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+
+    var compat_type_fields = builtin_type.fields[0..builtin_type.fields.len].*;
+    for (&compat_type_fields) |*field| {
+        field.name = type_new_fields.get(field.name).?;
+    }
+
+    break :TypeCompat @Type(.{ .Union = .{
+        .layout = .auto,
+        .tag_type = TypeCompatTag,
+        .fields = &compat_type_fields,
+        .decls = &.{},
+    } });
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -31,7 +31,7 @@ pub const std_options: std.Options = .{
 
 pub fn logImpl(
     comptime level: log.Level,
-    comptime scope: @Type(.EnumLiteral),
+    comptime scope: @Type(.enum_literal),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/src/zig_writer.zig
+++ b/src/zig_writer.zig
@@ -57,7 +57,14 @@ pub fn ZigWriter(comptime Writer: type) type {
                         const arg = @field(args, arg_fields[current_arg].name);
                         const arg_type_info = @typeInfo(@TypeOf(arg));
                         if (arg_type_info == .Pointer and arg_type_info.Pointer.size == .Slice and arg_type_info.Pointer.child == u8) {
-                            try w.out.print("{s}", .{arg});
+                            for (arg) |char| {
+                                switch (char) {
+                                    // Zig is very tab-hostile, so we have to replace tabs with spaces.
+                                    // This is most relevant when translating documentation.
+                                    '\t' => try w.out.writeAll("    "),
+                                    else => try w.out.writeByte(char),
+                                }
+                            }
                         } else {
                             try w.out.print("{}", .{arg});
                         }

--- a/src/zig_writer.zig
+++ b/src/zig_writer.zig
@@ -29,7 +29,7 @@ pub fn ZigWriter(comptime Writer: type) type {
         /// made into its own project.
         pub fn print(w: Self, comptime fmt: []const u8, args: anytype) Error!void {
             @setEvalBranchQuota(100_000);
-            const arg_fields = @typeInfo(@TypeOf(args)).Struct.fields;
+            const arg_fields = @typeInfo(@TypeOf(args)).@"struct".fields;
 
             comptime var current_arg = 0;
             comptime var i = 0;
@@ -56,7 +56,7 @@ pub fn ZigWriter(comptime Writer: type) type {
                     'L' => {
                         const arg = @field(args, arg_fields[current_arg].name);
                         const arg_type_info = @typeInfo(@TypeOf(arg));
-                        if (arg_type_info == .Pointer and arg_type_info.Pointer.size == .Slice and arg_type_info.Pointer.child == u8) {
+                        if (arg_type_info == .pointer and arg_type_info.pointer.size == .Slice and arg_type_info.pointer.child == u8) {
                             for (arg) |char| {
                                 switch (char) {
                                     // Zig is very tab-hostile, so we have to replace tabs with spaces.

--- a/test/bindings.zig
+++ b/test/bindings.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
+const compat = @import("abi/compat.zig");
 
 pub fn refAllBindings(comptime T: type) void {
     @setEvalBranchQuota(100000);
 
     inline for (comptime std.meta.declarations(T)) |decl| {
         if (@TypeOf(@field(T, decl.name)) == type) {
-            switch (@typeInfo(@field(T, decl.name))) {
+            switch (compat.typeInfo(@field(T, decl.name))) {
                 .@"struct", .@"enum", .@"union", .@"opaque" => std.testing.refAllDecls(@field(T, decl.name)),
                 else => {},
             }

--- a/test/bindings.zig
+++ b/test/bindings.zig
@@ -6,7 +6,7 @@ pub fn refAllBindings(comptime T: type) void {
     inline for (comptime std.meta.declarations(T)) |decl| {
         if (@TypeOf(@field(T, decl.name)) == type) {
             switch (@typeInfo(@field(T, decl.name))) {
-                .Struct, .Enum, .Union, .Opaque => std.testing.refAllDecls(@field(T, decl.name)),
+                .@"struct", .@"enum", .@"union", .@"opaque" => std.testing.refAllDecls(@field(T, decl.name)),
                 else => {},
             }
         }

--- a/test/build.zig
+++ b/test/build.zig
@@ -480,7 +480,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             });
             abi_tests.root_module.addImport(module, gobject.module(module));
-            inline for (@typeInfo(gobject_build.libraries).Struct.decls) |lib_decl| {
+            inline for (comptime std.meta.declarations(gobject_build.libraries)) |lib_decl| {
                 if (std.mem.eql(u8, lib_decl.name, module)) {
                     @field(gobject_build.libraries, lib_decl.name).linkTo(&abi_tests.root_module);
                 }

--- a/test/gobject2.zig
+++ b/test/gobject2.zig
@@ -109,7 +109,7 @@ test "Value" {
             one: bool = false,
             two: bool = false,
             three: bool = false,
-            _padding1: @Type(.{ .Int = .{
+            _padding1: @Type(.{ .int = .{
                 .signedness = .unsigned,
                 .bits = @bitSizeOf(c_uint) - 3,
             } }) = 0,
@@ -217,9 +217,9 @@ test "enum type" {
     };
 
     const enum_type_class: *gobject.EnumClass = @ptrCast(gobject.TypeClass.ref(MyEnum.getGObjectType()));
-    try expectEqual(1, enum_type_class.minimum);
-    try expectEqual(3, enum_type_class.maximum);
-    try expectEqual(3, enum_type_class.n_values);
+    try expectEqual(1, enum_type_class.f_minimum);
+    try expectEqual(3, enum_type_class.f_maximum);
+    try expectEqual(3, enum_type_class.f_n_values);
 }
 
 test "flags type" {
@@ -228,7 +228,7 @@ test "flags type" {
         two: i1 = -1,
         _padding0: u2 = 0,
         three: u1 = 1,
-        _padding1: @Type(.{ .Int = .{
+        _padding1: @Type(.{ .int = .{
             .signedness = .unsigned,
             .bits = @bitSizeOf(c_uint) - 5,
         } }) = 0,
@@ -237,6 +237,6 @@ test "flags type" {
     };
 
     const flags_type_class: *gobject.FlagsClass = @ptrCast(gobject.TypeClass.ref(MyFlags.getGObjectType()));
-    try expectEqual(0b10011, flags_type_class.mask);
-    try expectEqual(3, flags_type_class.n_values);
+    try expectEqual(0b10011, flags_type_class.f_mask);
+    try expectEqual(3, flags_type_class.f_n_values);
 }

--- a/test/gobject2.zig
+++ b/test/gobject2.zig
@@ -1,4 +1,5 @@
 const gobject = @import("gobject");
+const compat = @import("abi/compat.zig");
 
 const std = @import("std");
 const bindings = @import("bindings.zig");
@@ -109,7 +110,7 @@ test "Value" {
             one: bool = false,
             two: bool = false,
             three: bool = false,
-            _padding1: @Type(.{ .int = .{
+            _padding1: compat.Reify(.{ .int = .{
                 .signedness = .unsigned,
                 .bits = @bitSizeOf(c_uint) - 3,
             } }) = 0,
@@ -228,7 +229,7 @@ test "flags type" {
         two: i1 = -1,
         _padding0: u2 = 0,
         three: u1 = 1,
-        _padding1: @Type(.{ .int = .{
+        _padding1: compat.Reify(.{ .int = .{
             .signedness = .unsigned,
             .bits = @bitSizeOf(c_uint) - 5,
         } }) = 0,


### PR DESCRIPTION
Follow-up/continuation of #72.

The largest user-visible change here is the prefixing of field names with `f_`; everything else should be transparent to existing use-cases. In my Nonograms application, this had minimal impact (it simply prompted me to use the `virtual_methods` helpers in more places, which was actually a good thing).