### PR TITLE
Fix GIR fix detection when using profiles

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -289,7 +289,7 @@ pub fn build(b: *std.Build) void {
         }
         if (gir_profile) |profile| {
             for (gir_fixes_profiles.get(profile)) |fix| {
-                applicable_fixes.append(b.fmt("{1s}gir-fixes/{0}/{1s}.xslt", .{ profile, fix })) catch @panic("OOM");
+                applicable_fixes.append(b.fmt("{1s}=gir-fixes/{0s}/{1s}.xslt", .{ @tagName(profile), fix })) catch @panic("OOM");
             }
         }
         break :gir_fixes applicable_fixes.toOwnedSlice() catch @panic("OOM");


### PR DESCRIPTION
I was trying to [run actions][1] on the repo when trying different zig versions for:
https://github.com/ianprime0509/zig-gobject/issues/79

I got this error when trying to build bindings for the gnome 46 sdk:

```
| + zig build codegen -Dgir-profile=gnome46 -Dgir-files-path=/var/lib/flatpak/runtime/org.gnome.Sdk/x86_64/46/active/files/share/gir-1.0/
thread 83 panic: Invalid GIR fix provided (format: module=xslt-path)
| /home/robert/src/zig-gobject/build.zig:314:76: 0x141e410 in build (build)
|             const sep_pos = std.mem.indexOfScalar(u8, gir_fix, '=') orelse @panic("Invalid GIR fix provided (format: module=xslt-path)");
|                                                                            ^
| /usr/local/bin/lib/std/Build.zig:2294:33: 0x1402083 in runBuild__anon_4920 (build)
|         .void => build_zig.build(b),
|                                 ^
| /usr/local/bin/lib/compiler/build_runner.zig:335:29: 0x13fcca7 in main (build)
|         try builder.runBuild(root);
|                             ^
| /usr/local/bin/lib/std/start.zig:621:37: 0x13d7b32 in posixCallMainAndExit (build)
|             const result = root.main() catch |err| {
|                                     ^
| /usr/local/bin/lib/std/start.zig:250:5: 0x13d770f in _start (build)
|     asm volatile (switch (native_arch) {
|     ^
| ???:?:?: 0x0 in ??? (???)
| error: the following build command crashed:
| /home/robert/src/zig-gobject/.zig-cache/o/36e513415c8d6c382ef02b82ae0bc3e5/build /usr/local/bin/zig /usr/local/bin/lib /home/robert/src/zig-gobject /home/robert/src/zig-gobject/.zig-cache /root/.cache/zig --seed 0xd81305d -Z145d44f854504cb8 codegen -Dgir-profile=gnome46 -Dgir-files-path=/var/lib/flatpak/runtime/org.gnome.Sdk/x86_64/46/active/files/share/gir-1.0/
```

this patch fixes it for me :)

[1]: https://github.com/robertgzr/zig-gobject/actions/runs/11277755222/job/31364649107
