### PR TITLE
feat: add `buildCompileResources` helper

### DIFF
--- a/src/build/build_base.zig
+++ b/src/build/build_base.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+
+/// A library accessible through the generated bindings.
+///
+/// While the generated bindings are typically used through modules
+/// (e.g. `gobject.module("glib-2.0")`), there are cases where it is
+/// useful to have additional information about the libraries exposed
+/// to the build script. For example, if any files in the root module
+/// of the application want to import a library's C headers directly,
+/// it will be necessary to link the library directly to the root module
+/// using `Library.linkTo` so the include paths will be available.
+pub const Library = struct {
+    /// System libraries to be linked using pkg-config.
+    system_libraries: []const []const u8,
+
+    /// Links `lib` to `module`.
+    pub fn linkTo(lib: Library, module: *std.Build.Module) void {
+        module.link_libc = true;
+        for (lib.system_libraries) |system_lib| {
+            module.linkSystemLibrary(system_lib, .{ .use_pkg_config = .force });
+        }
+    }
+};
+
+/// Returns a `std.Build.Module` created by compiling the GResources file at `path`.
+///
+/// This requires the `glib-compile-resources` system command to be available.
+pub fn addCompileResources(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    path: std.Build.LazyPath,
+) *std.Build.Module {
+    const compile_resources, const module = addCompileResourcesInternal(b, target, path);
+    compile_resources.addArg("--sourcedir");
+    compile_resources.addDirectoryArg(path.dirname());
+    compile_resources.addArg("--dependency-file");
+    _ = compile_resources.addDepFileOutputArg("gresources-deps");
+
+    return module;
+}
+
+fn addCompileResourcesInternal(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    path: std.Build.LazyPath,
+) struct { *std.Build.Step.Run, *std.Build.Module } {
+    const compile_resources = b.addSystemCommand(&.{ "glib-compile-resources", "--generate-source" });
+    compile_resources.addArg("--target");
+    const gresources_c = compile_resources.addOutputFileArg("gresources.c");
+    compile_resources.addFileArg(path);
+
+    const module = b.createModule(.{ .target = target });
+    module.addCSourceFile(.{ .file = gresources_c });
+    @This().libraries.gio2.linkTo(module);
+    return .{ compile_resources, module };
+}
+
+/// Returns a builder for a compiled GResource bundle.
+///
+/// Calling `CompileResources.build` on the returned builder requires the
+/// `glib-compile-resources` system command to be installed.
+pub fn buildCompileResources(gobject_dependency: *std.Build.Dependency) CompileResources {
+    return .{ .b = gobject_dependency.builder };
+}
+
+/// A builder for a compiled GResource bundle.
+pub const CompileResources = struct {
+    b: *std.Build,
+    groups: std.ArrayListUnmanaged(*Group) = .{},
+
+    var build_gresources_xml_exe: ?*std.Build.Step.Compile = null;
+
+    /// Builds the GResource bundle as a module. The module must be imported
+    /// into the compilation for the resources to be loaded.
+    pub fn build(cr: CompileResources, target: std.Build.ResolvedTarget) *std.Build.Module {
+        const run = cr.b.addRunArtifact(build_gresources_xml_exe orelse exe: {
+            const exe = cr.b.addExecutable(.{
+                .name = "build-gresources-xml",
+                .root_source_file = cr.b.path("build/build_gresources_xml.zig"),
+                .target = cr.b.host,
+                .optimize = .Debug,
+            });
+            build_gresources_xml_exe = exe;
+            break :exe exe;
+        });
+
+        for (cr.groups.items) |group| {
+            run.addArg(cr.b.fmt("--prefix={s}", .{group.prefix}));
+            for (group.files.items) |file| {
+                run.addArg(cr.b.fmt("--alias={s}", .{file.name}));
+                if (file.options.compressed) {
+                    run.addArg("--compressed");
+                }
+                for (file.options.preprocess) |preprocessor| {
+                    run.addArg(cr.b.fmt("--preprocess={s}", .{preprocessor.name()}));
+                }
+                run.addPrefixedFileArg("--path=", file.path);
+            }
+        }
+        const xml = run.addPrefixedOutputFileArg("--output=", "gresources.xml");
+
+        _, const module = addCompileResourcesInternal(cr.b, target, xml);
+        return module;
+    }
+
+    /// Adds a group of resources showing a common prefix.
+    pub fn addGroup(cr: *CompileResources, prefix: []const u8) *Group {
+        const group = cr.b.allocator.create(Group) catch @panic("OOM");
+        group.* = .{ .owner = cr, .prefix = prefix };
+        cr.groups.append(cr.b.allocator, group) catch @panic("OOM");
+        return group;
+    }
+
+    pub const Group = struct {
+        owner: *CompileResources,
+        prefix: []const u8,
+        files: std.ArrayListUnmanaged(File) = .{},
+
+        /// Adds the file at `path` as a resource named `name` (within the
+        /// prefix of the containing group).
+        pub fn addFile(g: *Group, name: []const u8, path: std.Build.LazyPath, options: File.Options) void {
+            g.files.append(g.owner.b.allocator, .{
+                .name = name,
+                .path = path,
+                .options = options,
+            }) catch @panic("OOM");
+        }
+    };
+
+    pub const File = struct {
+        name: []const u8,
+        path: std.Build.LazyPath,
+        options: Options = .{},
+
+        pub const Options = struct {
+            compressed: bool = false,
+            preprocess: []const Preprocessor = &.{},
+        };
+
+        pub const Preprocessor = union(enum) {
+            xml_stripblanks,
+            json_stripblanks,
+            other: []const u8,
+
+            pub fn name(p: Preprocessor) []const u8 {
+                return switch (p) {
+                    .xml_stripblanks => "xml-stripblanks",
+                    .json_stripblanks => "json-stripblanks",
+                    .other => |s| s,
+                };
+            }
+        };
+    };
+};

--- a/src/build/build_gresources_xml.zig
+++ b/src/build/build_gresources_xml.zig
@@ -1,0 +1,87 @@
+//! A simple wrapper to build a `gresources.xml` description from command-line
+//! arguments.
+//!
+//! This program is only meant to be invoked internally as part of the
+//! zig-gobject build helper logic, hence, having a "user-friendly" interface
+//! is not a goal.
+
+const std = @import("std");
+
+pub fn main() !void {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const args = try std.process.argsAlloc(arena);
+
+    var output_path: ?[]const u8 = null;
+    var output = std.ArrayList(u8).init(arena);
+    try output.appendSlice("<?xml version=\"1.0\" encoding=\"UTF-8\"?><gresources>");
+
+    var i: usize = 1;
+    var seen_prefix = false;
+    var seen_preprocessor = false;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.startsWith(u8, arg, "--prefix=")) {
+            if (seen_prefix) {
+                try output.appendSlice("</gresource>");
+            }
+            try output.writer().print("<gresource prefix=\"{}\">", .{fmtXml(arg["--prefix=".len..])});
+            seen_prefix = true;
+        } else if (std.mem.startsWith(u8, arg, "--alias=")) {
+            try output.writer().print("<file alias=\"{}\"", .{fmtXml(arg["--alias=".len..])});
+        } else if (std.mem.eql(u8, arg, "--compressed")) {
+            try output.appendSlice(" compressed=\"true\"");
+        } else if (std.mem.startsWith(u8, arg, "--preprocess=")) {
+            if (seen_preprocessor) {
+                try output.writer().print(",{}", .{fmtXml(arg["--preprocess=".len..])});
+            } else {
+                try output.writer().print(" preprocess=\"{}", .{fmtXml(arg["--preprocess=".len..])});
+            }
+            seen_preprocessor = true;
+        } else if (std.mem.startsWith(u8, arg, "--path=")) {
+            if (seen_preprocessor) {
+                try output.append('"');
+            }
+            try output.writer().print(">{}</file>", .{fmtXml(arg["--path=".len..])});
+            seen_preprocessor = false;
+        } else if (std.mem.startsWith(u8, arg, "--output=")) {
+            output_path = arg["--output=".len..];
+        } else {
+            return error.UnrecognizedOption;
+        }
+    }
+
+    if (seen_prefix) {
+        try output.appendSlice("</gresource>");
+    }
+    try output.appendSlice("</gresources>");
+
+    try std.fs.cwd().writeFile(.{
+        .sub_path = output_path orelse return error.MissingOutput,
+        .data = output.items,
+    });
+}
+
+fn fmtXml(s: []const u8) std.fmt.Formatter(formatXml) {
+    return .{ .data = s };
+}
+
+fn formatXml(s: []const u8, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+    _ = fmt;
+    _ = options;
+
+    var start: usize = 0;
+    while (std.mem.indexOfAnyPos(u8, s, start, "&<\"")) |pos| {
+        try writer.writeAll(s[start..pos]);
+        try writer.writeAll(switch (s[pos]) {
+            '&' => "&amp;",
+            '<' => "&lt;",
+            '"' => "&quot;",
+            else => unreachable,
+        });
+        start = pos + 1;
+    }
+    try writer.writeAll(s[start..]);
+}


### PR DESCRIPTION
This allows a `gresources.xml` descriptor to be built from lazy paths, which is essential if any of the resource files are generated.