### PR TITLE
include data files in build.zig.zon paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,9 @@
     .name = "gobject_codegen",
     .version = "0.2.2",
     .paths = .{
+        "binding-overrides",
+        "extensions",
+        "gir-fixes",
         "src",
         "LICENSE",
         "README.md",


### PR DESCRIPTION
This makes it possible to use `zig-gobject` as a Zig dependency to build custom GObject bindings. I've been playing with doing exactly that here:

https://github.com/jcollie/ghostty-gobject