### PR TITLE
feat: add support for GNOME 48 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ testing purposes. The best way to get a consistent environment for testing is to
 use [Flatpak](https://flatpak.org/):
 
 1. Install `flatpak`.
-2. Install the GNOME SDK: `flatpak install org.gnome.Sdk//47`
+2. Install the GNOME SDK: `flatpak install org.gnome.Sdk//48`
 
 The steps above only need to be done once per GNOME SDK version. To enter a
 development environment:
 
-1. Run `flatpak run --filesystem=home --share=network --share=ipc --socket=fallback-x11 --socket=wayland --device=dri --socket=session-bus org.gnome.Sdk//47`
+1. Run `flatpak run --filesystem=home --share=network --share=ipc --socket=fallback-x11 --socket=wayland --device=dri --socket=session-bus org.gnome.Sdk//48`
    - `--filesystem=home` - makes the user's home directory available within the
      container
    - `--share=network` - allows network access (needed to fetch `build.zig.zon`

--- a/build.zig
+++ b/build.zig
@@ -41,14 +41,13 @@ pub fn build(b: *std.Build) void {
     test_exe_step.dependOn(&b.addRunArtifact(exe_tests).step);
     test_step.dependOn(test_exe_step);
 
-    const GirProfile = enum { gnome46, gnome47 };
+    const GirProfile = enum { gnome47, gnome48 };
     const gir_profile = b.option(GirProfile, "gir-profile", "Predefined GIR profile for codegen");
     const codegen_modules: []const []const u8 = b.option([]const []const u8, "modules", "Modules to codegen") orelse if (gir_profile) |profile| switch (profile) {
-        .gnome46 => &.{
+        .gnome47 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",
-            "AppStreamGlib-1.0",
             "Atk-1.0",
             "Atspi-2.0",
             "cairo-1.0",
@@ -86,6 +85,7 @@ pub fn build(b: *std.Build) void {
             "Gsk-4.0",
             "Gst-1.0",
             "GstAllocators-1.0",
+            "GstAnalytics-1.0",
             "GstApp-1.0",
             "GstAudio-1.0",
             "GstBadAudio-1.0",
@@ -93,12 +93,14 @@ pub fn build(b: *std.Build) void {
             "GstCheck-1.0",
             "GstController-1.0",
             "GstCuda-1.0",
+            // "GstDxva-1.0", // Not usable on Linux
             "GstGL-1.0",
             "GstGLEGL-1.0",
             "GstGLWayland-1.0",
             "GstGLX11-1.0",
             "GstInsertBin-1.0",
             "GstMpegts-1.0",
+            "GstMse-1.0",
             "GstNet-1.0",
             "GstPbutils-1.0",
             "GstPlay-1.0",
@@ -139,6 +141,7 @@ pub fn build(b: *std.Build) void {
             "Secret-1",
             "Soup-3.0",
             "Tracker-3.0",
+            "Tsparql-3.0",
             // "Vulkan-1.0", // https://github.com/ianprime0509/zig-gobject/issues/89
             "WebKit2-4.1",
             "WebKit2WebExtension-4.1",
@@ -151,7 +154,7 @@ pub fn build(b: *std.Build) void {
             "Xmlb-2.0",
             "xrandr-1.3",
         },
-        .gnome47 => &.{
+        .gnome48 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",

--- a/flatpak-env.sh
+++ b/flatpak-env.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-sdk_version=${1:-47}
+sdk_version=${1:-48}
 exec flatpak run --filesystem=home --share=network --share=ipc --socket=fallback-x11 --socket=wayland --device=dri --socket=session-bus org.gnome.Sdk//$sdk_version

--- a/gir-fixes/Adw-1.xslt
+++ b/gir-fixes/Adw-1.xslt
@@ -11,12 +11,8 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="core:bitfield[@name='SearchTokenMatch']">
-    <!-- https://github.com/ianprime0509/zig-gobject/issues/47 -->
-    <xsl:copy>
-      <xsl:attribute name="bits">16</xsl:attribute>
-
-      <xsl:copy-of select="@* | node()" />
-    </xsl:copy>
+  <xsl:template match="core:function[@c:identifier='adw_easing_ease']/@name">
+    <!-- https://github.com/ianprime0509/zig-gobject/issues/105 -->
+    <xsl:attribute name="name">compute</xsl:attribute>
   </xsl:template>
 </xsl:stylesheet>

--- a/test/build.zig
+++ b/test/build.zig
@@ -256,14 +256,13 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run binding tests");
 
-    const GirProfile = enum { gnome46, gnome47 };
+    const GirProfile = enum { gnome47, gnome48 };
     const gir_profile = b.option(GirProfile, "gir-profile", "Predefined GIR profile for tests");
     const test_modules: []const []const u8 = b.option([]const []const u8, "modules", "Modules to test") orelse if (gir_profile) |profile| switch (profile) {
-        .gnome46 => &.{
+        .gnome47 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",
-            "AppStreamGlib-1.0",
             "Atk-1.0",
             "Atspi-2.0",
             "cairo-1.0",
@@ -301,6 +300,7 @@ pub fn build(b: *std.Build) void {
             "Gsk-4.0",
             "Gst-1.0",
             "GstAllocators-1.0",
+            "GstAnalytics-1.0",
             "GstApp-1.0",
             "GstAudio-1.0",
             "GstBadAudio-1.0",
@@ -308,12 +308,14 @@ pub fn build(b: *std.Build) void {
             "GstCheck-1.0",
             "GstController-1.0",
             "GstCuda-1.0",
+            // "GstDxva-1.0", // Not usable on Linux
             "GstGL-1.0",
             "GstGLEGL-1.0",
             "GstGLWayland-1.0",
             "GstGLX11-1.0",
             "GstInsertBin-1.0",
             "GstMpegts-1.0",
+            "GstMse-1.0",
             "GstNet-1.0",
             "GstPbutils-1.0",
             "GstPlay-1.0",
@@ -325,9 +327,9 @@ pub fn build(b: *std.Build) void {
             "GstTranscoder-1.0",
             "GstVa-1.0",
             "GstVideo-1.0",
-            // "GstVulkan-1.0", // Vulkan GIR is incorrect; all records should have pointer="1"
-            // "GstVulkanWayland-1.0", // Vulkan GIR is incorrect; all records should have pointer="1"
-            // "GstVulkanXCB-1.0", // Vulkan GIR is incorrect; all records should have pointer="1"
+            // "GstVulkan-1.0", // https://github.com/ianprime0509/zig-gobject/issues/89
+            // "GstVulkanWayland-1.0", // https://github.com/ianprime0509/zig-gobject/issues/89
+            // "GstVulkanXCB-1.0", // https://github.com/ianprime0509/zig-gobject/issues/89
             "GstWebRTC-1.0",
             "Gtk-3.0",
             "Gtk-4.0",
@@ -354,6 +356,7 @@ pub fn build(b: *std.Build) void {
             "Secret-1",
             "Soup-3.0",
             "Tracker-3.0",
+            "Tsparql-3.0",
             // "Vulkan-1.0", // https://github.com/ianprime0509/zig-gobject/issues/89
             "WebKit2-4.1",
             "WebKit2WebExtension-4.1",
@@ -366,7 +369,7 @@ pub fn build(b: *std.Build) void {
             "Xmlb-2.0",
             "xrandr-1.3",
         },
-        .gnome47 => &.{
+        .gnome48 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",


### PR DESCRIPTION
TODO:

- [x] Fix binding and extension breakage
  - [x] `g_enum_register_static` and `g_flags_register_static` now correctly recognize the second parameter as a many-pointer rather than a single item pointer. This correction in GIR (to use an array type for the parameter) should be backported to GNOME 47 via a GIR fix for compatibility. See #104.
  - [x] Adw-1 `Easing` enum declares both an enum value and a function named `ease`, leading to a name collision. See #105.
- [x] Fix any ABI test breakage (~~some header files seem to be missing~~ seems to have just been some cache issue; after clearing out `.zig-cache` it worked fine)
- [x] Evaluate if any GIR fixes can be retired (e.g. #47 almost certainly can be)