### PR TITLE
Fix translation of Null-terminated arrays

### DIFF
--- a/gir-fixes/GLib-2.0.xslt
+++ b/gir-fixes/GLib-2.0.xslt
@@ -27,6 +27,22 @@
     </xsl:copy>
   </xsl:template>
 
+  <xsl:template match="core:parameter/core:array/core:type">
+    <xsl:variable name="paramName" select="../../@name"/>
+    <xsl:variable name="doc" select="../../../../core:doc"/>
+
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+      <xsl:if test="
+        $doc and (
+          contains($doc, concat('@', $paramName, ' is %NULL-terminated'))
+        )
+      ">
+        <xsl:attribute name="nullable">1</xsl:attribute>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="core:array[@c:type='gchar**' and not(@zero-terminated)]">
     <xsl:copy>
       <xsl:attribute name="zero-terminated">1</xsl:attribute>

--- a/gir-fixes/GLib-2.0.xslt
+++ b/gir-fixes/GLib-2.0.xslt
@@ -26,4 +26,12 @@
       <xsl:attribute name="c:type">gpointer</xsl:attribute>
     </xsl:copy>
   </xsl:template>
+
+  <xsl:template match="core:array[@c:type='gchar**' and not(@zero-terminated)]">
+    <xsl:copy>
+      <xsl:attribute name="zero-terminated">1</xsl:attribute>
+
+      <xsl:copy-of select="@* | node()" />
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/gir-fixes/Gio-2.0.xslt
+++ b/gir-fixes/Gio-2.0.xslt
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://www.gtk.org/introspection/core/1.0"
+    xmlns:core="http://www.gtk.org/introspection/core/1.0"
+    xmlns:c="http://www.gtk.org/introspection/c/1.0"
+    xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="core:array[../core:doc[contains(text(),'NULL-terminated array')]]">
+    <xsl:copy>
+      <xsl:attribute name="zero-terminated">1</xsl:attribute>
+
+      <xsl:copy-of select="@* | node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="core:return-value[core:doc[contains(text(),'or %NULL if')]] | core:parameter[core:doc[contains(text(),'%NULL to')]]">
+    <xsl:copy>
+      <xsl:attribute name="nullable">1</xsl:attribute>
+
+      <xsl:copy-of select="@* | node()" />
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/gir.zig
+++ b/src/gir.zig
@@ -1439,6 +1439,7 @@ pub const AnyType = union(enum) {
 pub const Type = struct {
     name: ?Name = null,
     c_type: ?[]const u8 = null,
+    nullable: bool = false,
 
     fn parse(allocator: Allocator, reader: anytype, current_ns: []const u8) !Type {
         const name = name: {
@@ -1449,12 +1450,17 @@ pub const Type = struct {
             const index = reader.attributeIndexNs(ns.c, "type") orelse break :c_type null;
             break :c_type try reader.attributeValueAlloc(allocator, index);
         };
+        const nullable = nullable: {
+            const index = reader.attributeIndex("nullable") orelse break :nullable false;
+            break :nullable mem.eql(u8, try reader.attributeValue(index), "1");
+        };
 
         try reader.skipElement();
 
         return .{
             .name = name,
             .c_type = c_type,
+            .nullable = nullable,
         };
     }
 };

--- a/src/translate.zig
+++ b/src/translate.zig
@@ -1531,7 +1531,7 @@ fn typeIsPointer(@"type": gir.Type, gobject_context: bool, ctx: TranslationConte
 }
 
 fn translateType(allocator: Allocator, @"type": gir.Type, options: TranslateTypeOptions, ctx: TranslationContext, out: anytype) Allocator.Error!void {
-    if (options.nullable and typeIsPointer(@"type", options.gobject_context, ctx)) {
+    if (@"type".nullable or (options.nullable and typeIsPointer(@"type", options.gobject_context, ctx))) {
         try out.print("?", .{});
     }
     const name = @"type".name orelse {


### PR DESCRIPTION
#### Summary:
Addresses issues related to the translation of null-terminated arrays in GLib and GIO bindings and adds a nullable attribute for type elements in GIR.

#### Detailed Changes:

1. **GIR transformation fixes:**
   - **Gio-2.0.xslt**: Corrected the handling of arrays documented as "NULL-terminated arrays", so they correctly include a `zero-terminated` attribute. Also corrects the handling of return values or parameters documented as "NULL if" or "NULL to".
   
   - **GLib-2.0.xslt**: 
   Fixed the transformation of `gchar**` arrays to ensure that they are properly marked with a `zero-terminated` attribute when necessary. This change resolves inconsistencies in how string arrays were being transformed, ensuring that they are handled correctly in the generated Zig code. 
   Additionally, adds the nullable attribute to types when the documentation contains "`parameter` is %NULL-terminated". This allows the zig translated type to accept null without enforcing a sentinel in the array.

2. **GIR translation adjustments:**
   - **Nullable Types**: Added logic to handle nullable types. Although this isn't part of the GIR introspection format, it helps translate cases where an array may be null-terminated. 
 
#### Impact:
Currently the pull request should only affect Gio and GLib translations.