### PR TITLE
`g_weak_ref_get` can return `NULL`

### DIFF
--- a/gir-fixes/GObject-2.0.xslt
+++ b/gir-fixes/GObject-2.0.xslt
@@ -42,4 +42,11 @@
       <core:type name="FlagsValue" c:type="GFlagsValue"/>
     </core:array>
   </xsl:template>
+
+  <xsl:template match="core:record[@name='WeakRef']/core:method[@name='get']/core:return-value">
+    <xsl:copy>
+      <xsl:attribute name="nullable">1</xsl:attribute>
+      <xsl:copy-of select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
`g_weak_ref_get` can return `NULL` according to the comments in the code, plus verified by examining the implementation. Yet the GIR doesn't mark it as nullable. This PR adds an fix for that.

https://gitlab.gnome.org/GNOME/glib/-/blob/main/gobject/gobject.c#L6175-6193