### PR TITLE
feat: add support for GNOME 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ testing purposes. The best way to get a consistent environment for testing is to
 use [Flatpak](https://flatpak.org/):
 
 1. Install `flatpak`.
-2. Install the GNOME SDK: `flatpak install org.gnome.Sdk//48`
+2. Install the GNOME SDK: `flatpak install org.gnome.Sdk//49`
 
 The steps above only need to be done once per GNOME SDK version. To enter a
 development environment:
 
-1. Run `flatpak run --filesystem=home --share=network --share=ipc --socket=fallback-x11 --socket=wayland --device=dri --socket=session-bus org.gnome.Sdk//48`
+1. Run `flatpak run --filesystem=home --share=network --share=ipc --socket=fallback-x11 --socket=wayland --device=dri --socket=session-bus org.gnome.Sdk//49`
    - `--filesystem=home` - makes the user's home directory available within the
      container
    - `--share=network` - allows network access (needed to fetch `build.zig.zon`

--- a/build.zig
+++ b/build.zig
@@ -31,10 +31,10 @@ pub fn build(b: *std.Build) void {
     test_exe_step.dependOn(&b.addRunArtifact(codegen_test).step);
     test_step.dependOn(test_exe_step);
 
-    const GirProfile = enum { gnome47, gnome48 };
+    const GirProfile = enum { gnome48, gnome49 };
     const gir_profile = b.option(GirProfile, "gir-profile", "Predefined GIR profile for codegen");
     const codegen_modules: []const []const u8 = b.option([]const []const u8, "modules", "Modules to codegen") orelse if (gir_profile) |profile| switch (profile) {
-        .gnome47 => &.{
+        .gnome48 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",
@@ -144,7 +144,7 @@ pub fn build(b: *std.Build) void {
             "Xmlb-2.0",
             "xrandr-1.3",
         },
-        .gnome48 => &.{
+        .gnome49 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",
@@ -179,6 +179,8 @@ pub fn build(b: *std.Build) void {
             "GL-1.0",
             "GLib-2.0",
             "GLibUnix-2.0",
+            "Gly-2",
+            "GlyGtk4-2",
             "GModule-2.0",
             "GObject-2.0",
             "Graphene-1.0",

--- a/flatpak-env.sh
+++ b/flatpak-env.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-sdk_version=${1:-48}
+sdk_version=${1:-49}
 exec flatpak run --filesystem=home --share=network --share=ipc --socket=fallback-x11 --socket=wayland --device=dri --socket=session-bus org.gnome.Sdk//$sdk_version

--- a/gir-fixes/GObject-2.0.xslt
+++ b/gir-fixes/GObject-2.0.xslt
@@ -29,20 +29,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="core:function[@c:identifier='g_enum_register_static']/core:parameters/core:parameter[@name='const_static_values']/core:type">
-    <!-- https://github.com/ianprime0509/zig-gobject/issues/104 -->
-    <core:array c:type="const GEnumValue*">
-      <core:type name="EnumValue" c:type="GEnumValue"/>
-    </core:array>
-  </xsl:template>
-
-  <xsl:template match="core:function[@c:identifier='g_flags_register_static']/core:parameters/core:parameter[@name='const_static_values']/core:type">
-    <!-- https://github.com/ianprime0509/zig-gobject/issues/104 -->
-    <core:array c:type="const GFlagsValue*">
-      <core:type name="FlagsValue" c:type="GFlagsValue"/>
-    </core:array>
-  </xsl:template>
-
   <xsl:template match="core:record[@name='WeakRef']/core:method[@name='get']/core:return-value">
     <xsl:copy>
       <xsl:attribute name="nullable">1</xsl:attribute>

--- a/test/build.zig
+++ b/test/build.zig
@@ -256,10 +256,10 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run binding tests");
 
-    const GirProfile = enum { gnome47, gnome48 };
+    const GirProfile = enum { gnome48, gnome49 };
     const gir_profile = b.option(GirProfile, "gir-profile", "Predefined GIR profile for tests");
     const test_modules: []const []const u8 = b.option([]const []const u8, "modules", "Modules to test") orelse if (gir_profile) |profile| switch (profile) {
-        .gnome47 => &.{
+        .gnome48 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",
@@ -369,7 +369,7 @@ pub fn build(b: *std.Build) void {
             "Xmlb-2.0",
             "xrandr-1.3",
         },
-        .gnome48 => &.{
+        .gnome49 => &.{
             "Adw-1",
             "AppStream-1.0",
             "AppStreamCompose-1.0",
@@ -404,6 +404,8 @@ pub fn build(b: *std.Build) void {
             "GL-1.0",
             "GLib-2.0",
             "GLibUnix-2.0",
+            "Gly-2",
+            "GlyGtk4-2",
             "GModule-2.0",
             "GObject-2.0",
             "Graphene-1.0",


### PR DESCRIPTION
Also removes GNOME 47, since only the most recent two GNOME releases are supported.

Closes #104 (no longer relevant as GNOME 47 is unsupported)