### PR TITLE
fix(gir): consider implied null-terminated for array types

### DIFF
--- a/gir-fixes/GLib-2.0.xslt
+++ b/gir-fixes/GLib-2.0.xslt
@@ -43,14 +43,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="core:array[@c:type='gchar**' and not(@zero-terminated)]">
-    <xsl:copy>
-      <xsl:attribute name="zero-terminated">1</xsl:attribute>
-
-      <xsl:copy-of select="@* | node()" />
-    </xsl:copy>
-  </xsl:template>
-
   <xsl:template match="core:function[@c:identifier='g_set_prgname_once'] |
                        core:function[@c:identifier='g_set_user_dirs']">
     <!-- https://github.com/ianprime0509/zig-gobject/issues/122 -->

--- a/gir-fixes/Gio-2.0.xslt
+++ b/gir-fixes/Gio-2.0.xslt
@@ -12,14 +12,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="core:array[../core:doc[contains(text(),'NULL-terminated array')]]">
-    <xsl:copy>
-      <xsl:attribute name="zero-terminated">1</xsl:attribute>
-
-      <xsl:copy-of select="@* | node()" />
-    </xsl:copy>
-  </xsl:template>
-
   <xsl:template match="core:return-value[core:doc[contains(text(),'or %NULL if')]] | core:parameter[core:doc[contains(text(),'%NULL to')]]">
     <xsl:copy>
       <xsl:attribute name="nullable">1</xsl:attribute>


### PR DESCRIPTION
Closes #70

**TODO**: see if the other remaining GIR fixes from #107 are still needed.
**TODO**: the heuristic for scalar array element types is ugly and probably should be improved
**TODO**: the test case for an array of `gpointer`s which itself has C type `gpointer` is very tricky and needs additional handling

There are cases to consider related to using `gpointer` as the C type for arrays:
- `xmlstarlet sel -t -m "//_:array[@c:type='gpointer']" -c ../../.. /usr/share/gir-1.0/*.gir`
- `xmlstarlet sel -t -m "//_:array[@c:type='gconstpointer']" -c ../../.. /usr/share/gir-1.0/*.gir`