### PR TITLE
ci: fix working directory permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,13 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
+      - name: Fix working directory permissions
+        run: |
+          # The container runs as root, but the working directory is created with UID/GID 1001.
+          # Normally this would be fine, as root can do whatever it wants, but within the Flatpak
+          # container, it seems that root is no longer able to use its superpowers.
+          chown root:root .
       - name: Run tests
         run: |
           .github/workflows/flatpak-run.sh ${{ matrix.gnome-version }} <<EOF

--- a/.github/workflows/flatpak-run.sh
+++ b/.github/workflows/flatpak-run.sh
@@ -11,9 +11,7 @@ cat >>"$script_path"
 chmod +x "$script_path"
 
 exec flatpak run \
-  --filesystem="$PWD" \
-  --filesystem="$tmp_dir" \
-  --filesystem="$zig_bin_dir":ro \
+  --filesystem=host \
   --share=network \
   --share=ipc \
   --socket=fallback-x11 \


### PR DESCRIPTION
The CI wasn't working due to an issue with directory permissions in the container.