### PR TITLE
minor fixes to make zig-gobject work with a zig 0.16 project.

### DIFF
--- a/example/build.zig
+++ b/example/build.zig
@@ -28,6 +28,7 @@ pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{
         .name = "zig-gobject-examples",
         .root_module = mod,
+        .use_llvm = true,
     });
     b.installArtifact(exe);
 

--- a/src/build/build_base.zig
+++ b/src/build/build_base.zig
@@ -66,7 +66,7 @@ pub fn buildCompileResources(gobject_dependency: *std.Build.Dependency) CompileR
 /// A builder for a compiled GResource bundle.
 pub const CompileResources = struct {
     b: *std.Build,
-    groups: std.ArrayListUnmanaged(*Group) = .{},
+    groups: std.ArrayListUnmanaged(*Group) = .empty,
 
     var build_gresources_xml_exe: ?*std.Build.Step.Compile = null;
 
@@ -116,7 +116,7 @@ pub const CompileResources = struct {
     pub const Group = struct {
         owner: *CompileResources,
         prefix: []const u8,
-        files: std.ArrayListUnmanaged(File) = .{},
+        files: std.ArrayListUnmanaged(File) = .empty,
 
         /// Adds the file at `path` as a resource named `name` (within the
         /// prefix of the containing group).

--- a/src/build/build_gresources_xml.zig
+++ b/src/build/build_gresources_xml.zig
@@ -7,12 +7,11 @@
 
 const std = @import("std");
 
-pub fn main() !void {
-    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-
-    const args = try std.process.argsAlloc(arena);
+pub fn main(init: std.process.Init) !void {
+    const arena = init.arena.allocator();
+    const raw_args = init.minimal.args.vector;
+    const args = try arena.alloc([]const u8, raw_args.len);
+    for (raw_args, args) |raw, *arg| arg.* = std.mem.span(raw);
 
     var output_path: ?[]const u8 = null;
     var output: std.ArrayList(u8) = .empty;
@@ -58,7 +57,7 @@ pub fn main() !void {
     }
     try output.appendSlice(arena, "</gresources>");
 
-    try std.fs.cwd().writeFile(.{
+    try std.Io.Dir.writeFile(std.Io.Dir.cwd(), init.io, .{
         .sub_path = output_path orelse return error.MissingOutput,
         .data = output.items,
     });


### PR DESCRIPTION
there is some  problems with using a zig 0.16  project against zig-gobject.
building zig-gobject works fine and generation of bindings also, but when compiling against the generated binding there is issues.

- init arrays with .empty, not .{}
- use juicy main to get args
- use Io interface to write files
- use llvm to build examples, the native zig compiler, give .sframe errors when link with lib compiled with gcc 16.1.1