### PR TITLE
chore(gir-fixes): remove obsolete fix

### DIFF
--- a/gir-fixes/GLib-2.0.xslt
+++ b/gir-fixes/GLib-2.0.xslt
@@ -51,11 +51,6 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="core:function[@c:identifier='g_set_prgname_once'] |
-                       core:function[@c:identifier='g_set_user_dirs']">
-    <!-- https://github.com/ianprime0509/zig-gobject/issues/122 -->
-  </xsl:template>
-
   <xsl:template match="core:record[@c:type='GVariant']/@glib:get-type">
     <!-- https://github.com/ianprime0509/zig-gobject/issues/123 -->
   </xsl:template>


### PR DESCRIPTION
Closes #122

I actually can't figure out which GNOME SDK version this was an issue in, but it's not in any of the supported ones.